### PR TITLE
Update Ducktape to version 0.16.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Ducktape project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.22] - 2025-05-12
+### Changed
+- Refactored utility functions for improved clarity and maintainability
+- Enhanced calendar extraction in NLP commands
+- Improved time parsing for relative dates
+
 ## [0.16.21] - 2025-05-11
 ### Fixed
 - Improved time extraction for 'tonight' pattern in natural language parser.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ducktape"
-version = "0.16.21"
+version = "0.16.22"
 edition = "2021"
 authors = ["DuckTapeAI"]
 description = "A terminal-based calendar management tool with natural language processing and AI integration"

--- a/README.md
+++ b/README.md
@@ -206,12 +206,11 @@ For more troubleshooting tips, visit our documentation at [ducktapeai.com/docs](
 
 ---
 
-## Recent Updates (v0.16.15)
+## Recent Updates (v0.16.22)
 
-- Enhanced support for recurring event patterns in calendar operations
-- Improved handling of timezone conversions for international meetings
-- Refined error messaging for better user experience
-- Updated dependencies for better performance and security
+- Refactored utility functions for improved clarity and maintainability
+- Enhanced calendar extraction in NLP commands
+- Improved time parsing for relative dates
 - Fixed edge cases in time parsing for specific date formats
 - Improved stability in WebSocket connections for API integrations
 


### PR DESCRIPTION
This PR updates Ducktape to version 0.16.22 and updates documentation to reflect the new release. 

## Changes
- Updated version in Cargo.toml to 0.16.22
- Updated CHANGELOG.md with new features and improvements
- Updated README.md to reflect version 0.16.22 and latest features